### PR TITLE
angular-animate and express-less version change

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,7 @@
     "angular-cookies": "~1.2.23",
     "angular-sanitize": "~1.2.23",
     "angular-route": "~1.2.23",
+    "angular-animate": "~1.2.0",
     "bootstrap": "~3.2.0",
     "jquery": "<2.0.0",
     "angular-strap": "~2.0.5",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "coffee-middleware": "^0.2.1",
     "coffee-script": "^1.8.0",
     "express": "^4.6.1",
-    "express-less": "0.0.4",
+    "express-less": "^0.0.5",
     "logfmt": "^1.1.2",
     "request": "^2.40.0"
   },


### PR DESCRIPTION
Hi,

I had to make these change to make the app running, due to new version of package that are not compatible with old one.

specify the version for angular-animate to make it compatible with angular version need by other package
change express-less version to 0.0.5 to avoid crash with the old version 0.0.4 (see new version of less package)
